### PR TITLE
bugfix

### DIFF
--- a/gyazo
+++ b/gyazo
@@ -65,7 +65,7 @@ else
 end
 Net::HTTP::Proxy(proxy_host, proxy_port).start(HOST,80) {|http|
   res = http.post(CGI,data,header)
-  url = res.response.to_ary[1]
+  url = res.response.body
   puts url
   if system "which #{clipboard_cmd} >/dev/null 2>&1" then
     system "echo -n '#{url}' | #{clipboard_cmd}"


### PR DESCRIPTION
こちらの環境

```
$ uname -a
Linux yaletown 2.6.39-gentoo-r3 #1 SMP Sat Sep 3 10:13:32 PDT 2011 i686 Intel(R) Core(TM) i5 CPU 650 @ 3.20GHz GenuineIntel GNU/Linux

$ ruby -v
ruby 1.9.3dev (2011-08-20 revision 33014) [i686-linux]
```

gyazoを動作させると

```
$ ./gyazo
./gyazo:68:in `block in <main>': undefined method `to_ary' for #<Net::HTTPOK 200 OK readbody=true> (NoMethodError)
  from /home/ujihisa/git/ruby/local/lib/ruby/1.9.1/net/http.rb:745:in `start'
  from /home/ujihisa/git/ruby/local/lib/ruby/1.9.1/net/http.rb:557:in `start'
  from ./gyazo:66:in `<main>'
vimshell: exit 1 "./gyazo"
```

というわけで、修正しました。
