### PR TITLE
[bugfix] add require openssl

### DIFF
--- a/src/gyazo.rb
+++ b/src/gyazo.rb
@@ -6,6 +6,7 @@ clipboard_cmd = 'xclip'
 
 require 'net/http'
 require 'open3'
+require 'openssl'
 require 'json'
 
 # get id


### PR DESCRIPTION
fix this
```
.../Gyazo-for-Linux/src/gyazo.rb:98:in `<main>': uninitialized constant OpenSSL (NameError)
```

