### PR TITLE
Fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,17 @@ https://gyazo.com/
 
 ### `apt-get` Install
 
-`curl -s https://packagecloud.io/install/repositories/gyazo/gyazo-for-linux/script.deb.sh | sudo bash`
-`sudo apt-get install gyazo`
+```bash
+curl -s https://packagecloud.io/install/repositories/gyazo/gyazo-for-linux/script.deb.sh | sudo bash
+sudo apt-get install gyazo
+```
 
 ### `yum` Install
 
-`curl -s https://packagecloud.io/install/repositories/gyazo/gyazo-for-linux/script.rpm.sh | sudo bash`
-`sudo yum install gyazo`
+```bash
+curl -s https://packagecloud.io/install/repositories/gyazo/gyazo-for-linux/script.rpm.sh | sudo bash
+sudo yum install gyazo
+```
 
 ### Add the Gyazo Icon to the Unity Launcher
 


### PR DESCRIPTION
The install instructions have 2 commands per section, so should use ``` rather than `