### PR TITLE
upload gif animation without converting

### DIFF
--- a/src/gyazo.rb
+++ b/src/gyazo.rb
@@ -45,7 +45,12 @@ tmpfile = "/tmp/image_upload#{$$}.png"
 imagefile = ARGV[0]
 
 if imagefile && File.exist?(imagefile) then
-  system "convert '#{imagefile}' '#{tmpfile}'"
+  out, err, status = Open3.capture3 "identify '#{imagefile}'"
+  if out.split("\n").size > 1 # NOTE: gif animation
+    system "cp '#{imagefile}' '#{tmpfile}'"
+  else
+    system "convert '#{imagefile}' '#{tmpfile}'"
+  end
 else
   command = (File.exist?(configfile) && YAML.load_file(configfile)['command']) || 'import'
   system "#{command} '#{tmpfile}'"


### PR DESCRIPTION
When uploading gif animation file, Gyazo-for-Linux converts animated gif file to some png files.

So that this PR skips converting gif animation to png files.
This function helps to upload gif animation captured by other applications like a `byzanz`.

Below screen capture was captured by `byzanz` then it was uploaded to `gyazo.com`.
 [![https://gyazo.com/d7cc41077086adaf1a44abec457333c3](https://i.gyazo.com/d7cc41077086adaf1a44abec457333c3.gif)](https://gyazo.com/d7cc41077086adaf1a44abec457333c3)