### PR TITLE
tiny changes about fixing evaluation order

### DIFF
--- a/src/gyazo.rb
+++ b/src/gyazo.rb
@@ -51,7 +51,7 @@ out, err, status = Open3.capture3 "xprop -id #{active_window_id} | grep \"_NET_W
 
 pid = out.chomp
 
-application_name = `ps -p #{pid} -o comm=`.chomp
+application_name = "ps -p #{pid} -o comm=".chomp
 # capture png file
 tmpfile = "/tmp/image_upload#{$$}.png"
 imagefile = ARGV[0]

--- a/src/gyazo.rb
+++ b/src/gyazo.rb
@@ -43,7 +43,8 @@ end
 
 # get active window name
 
-active_window_id = `xprop -root | grep "_NET_ACTIVE_WINDOW(WINDOW)" | cut -d ' ' -f 5`.chomp
+window_property = "_NET_ACTIVE_WINDOW(WINDOW)"
+active_window_id = "xprop -root | grep window_property | cut -d ' ' -f 5".chomp
 out, err, status = Open3.capture3 "xwininfo -id #{active_window_id} | grep \"xwininfo: Window id: \"|sed \"s/xwininfo: Window id: #{active_window_id}//\""
 active_window_name = out.chomp
 out, err, status = Open3.capture3 "xprop -id #{active_window_id} | grep \"_NET_WM_PID(CARDINAL)\" | sed s/_NET_WM_PID\\(CARDINAL\\)\\ =\\ //"


### PR DESCRIPTION
I have used this application in Ubuntu 20.04. In using this, there is some problem below.
1. In running `gyazo` from command line, I get the following error almost every time and sometimes it stops.
`error: process ID list syntax error`
(maybe this is related to #166 .)
2. In capturing the screen, the first capturing makes no sense and only the second capturing is used for generating figure. This happened both when I started it from the command line and when I started it from the Unity launcher.

By this pull request, 1. and 2. will be resolved. Each commit fixed the above problems, respectively in my environment.
I think this problem is related to the evaluation order of the variables in ruby.